### PR TITLE
Handle special cases in exit_success

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -475,8 +475,8 @@ def exit_success(jid, ext_source=None):
         ext_source=ext_source
     )
 
-    minions = data['Minions']
-    result = data['Result']
+    minions = data.get('Minions', [])
+    result = data.get('Result', {})
 
     for minion in minions:
         if minion in result and 'return' in result[minion]:
@@ -484,6 +484,9 @@ def exit_success(jid, ext_source=None):
         else:
             ret[minion] = False
 
+    for minion in result:
+        if 'return' in result[minion] and result[minion]['return']:
+            ret[minion] = True
     return ret
 
 


### PR DESCRIPTION
Make sure the logic in exit_success is equivalent to that of lookup_jid:
 - Have default values for 'Minions' and 'Result' in the data
 - If a job has return but is not listed in minions, consider it a success.

Handles the case where lookup_jid find the job but does not know the minions:

$ salt-run jobs.lookup_jid
....
StartTime:
    2017, Mar 01 03:50:59.396278
Target:
    unknown-target
Target-type:
User:
    root
jid:
    20170301035059396278

$ salt-run jobs.exit_success
Exception occurred in runner jobs.exit_success: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/client/mixins.py", line 395, in _low
    data['return'] = self.functions[fun](*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/runners/jobs.py", line 478, in exit_success
    minions = data['Minions']
KeyError: 'Minions'

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
